### PR TITLE
Add metadata output to a build JSON

### DIFF
--- a/brownie/project/compiler/__init__.py
+++ b/brownie/project/compiler/__init__.py
@@ -31,7 +31,7 @@ STANDARD_JSON: Dict = {
     "settings": {
         "outputSelection": {
             "*": {
-                "*": ["abi", "devdoc", "evm.bytecode", "evm.deployedBytecode", "userdoc"],
+                "*": ["abi", "devdoc", "evm.bytecode", "evm.deployedBytecode", "userdoc", "metadata"],
                 "": ["ast"],
             }
         },
@@ -348,6 +348,7 @@ def generate_build_json(
                 "source": source,
                 "sourceMap": output_evm["bytecode"].get("sourceMap", ""),
                 "sourcePath": path_str,
+                'metadata': output_json['contracts'][path_str][contract_name]['metadata'],
             }
         )
         size = len(remove_0x_prefix(output_evm["deployedBytecode"]["object"])) / 2  # type: ignore


### PR DESCRIPTION
### What I did

Added a metadata output to solc which is needed for Sourcify and IPFS source verification

Related issue: #931

### How I did it

Changed solc call parameters

### How to verify it

Build JSONs in `build/contracts/` after compilation now contain a string property `metadata`

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation
- [ ] I have added an entry to the changelog

How do I proceed with the rest of the checklist points, if needed?
